### PR TITLE
fix: ensure predicates are declared with type guards

### DIFF
--- a/src/predicates.ts
+++ b/src/predicates.ts
@@ -4,37 +4,33 @@ export function isString(value: unknown): value is string {
   return typeof value === 'string';
 }
 
-export const isAlphanumeric: PredicateFn = function isAlphanumeric(
-  value,
-): value is string {
+export function isAlphanumeric(value: unknown): value is string {
   return isString(value) && /^[A-Za-z0-9]+$/.test(value);
-};
+}
 
 /**
  * BSNR (Betriebsstättennummer) ist eine eindeutige Zuordnung von Leistungen zu dem entsprechenden Ort der Leistungserbringung ermöglicht,
  * für alle vertrags(zahn)ärztlichen Leistungserbringer gültig
  * und klar abzugrenzen vom Institutskennzeichen (IK-Nummer) eines Krankenhauses.
  */
-export const isBSNR: PredicateFn = function isBSNR(value): value is string {
+export function isBSNR(value: unknown): value is string {
   return isString(value) && /^\d{9}$/.test(value);
-};
+}
 
 // Taken from https://emailregex.com
 export const EMAIL_REGEX =
   // eslint-disable-next-line no-useless-escape
   /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
-export const isEmail: PredicateFn = function isEmail(value): value is string {
+export function isEmail(value: unknown): value is string {
   return isString(value) && EMAIL_REGEX.test(value);
-};
+}
 
-export const isOnlyDigits: PredicateFn = function isOnlyDigits(
-  value,
-): value is string {
+export function isOnlyDigits(value: unknown): value is string {
   return isString(value) && /^\d+$/.test(value);
-};
+}
 
-export const isURL: PredicateFn = function isURL(value): value is string {
+export function isURL(value: unknown): value is string {
   if (!isString(value)) {
     return false;
   }
@@ -47,24 +43,22 @@ export const isURL: PredicateFn = function isURL(value): value is string {
   } catch {
     return false;
   }
-};
+}
 
-export const isWord: PredicateFn = function isWord(value): value is string {
+export function isWord(value: unknown): value is string {
   return isString(value) && /^[\w-]+$/.test(value);
-};
+}
 
-export const isLabId: PredicateFn = function isLabId(value): value is string {
+export function isLabId(value: unknown): value is string {
   return isString(value) && /^\d{2}-\d{6}$/.test(value);
-};
+}
 
-export const isRackBarcode: PredicateFn = function isRackBarcode(
-  value,
-): value is string {
+export function isRackBarcode(value: unknown): value is string {
   return isString(value) && /^[A-Z]{2}\d{8}$/.test(value);
-};
+}
 
-export const isNotNullish: PredicateFn = function isNotNullish<T>(
+export function isNotNullish<T>(
   value: T,
 ): value is Exclude<T, null | undefined> {
   return value != null;
-};
+}


### PR DESCRIPTION
Explicitly typing them as `: Predicate` erases the type guard:

```ts
export declare type PredicateFn = (value: unknown) => boolean;
export declare function isString(value: unknown): value is string;
export declare const isAlphanumeric: PredicateFn;
```