### PR TITLE
fix: allow to define maximumFractionDigits

### DIFF
--- a/src/germanNumber.test.ts
+++ b/src/germanNumber.test.ts
@@ -11,9 +11,21 @@ describe('formatGermanNumber', () => {
     expect(formatGermanNumber(123.123)).toBe('123,123');
     expect(formatGermanNumber(-123)).toBe('-123');
     expect(formatGermanNumber(123456)).toBe('123.456');
-    expect(formatGermanNumber(123456.1234567)).toBe('123.456,123457');
+    expect(formatGermanNumber(123456.1234566)).toBe('123.456,123457');
     expect(formatGermanNumber(null)).toBe('');
     expect(formatGermanNumber(Infinity)).toBe('∞');
+  });
+
+  it('defines maximumFractionDigits', () => {
+    expect(
+      formatGermanNumber(123.123456789, { maximumFractionDigits: 2 }),
+    ).toBe('123,12');
+    expect(formatGermanNumber(123.16, { maximumFractionDigits: 1 })).toBe(
+      '123,2',
+    );
+    expect(formatGermanNumber(123.123, { maximumFractionDigits: 4 })).toBe(
+      '123,123',
+    );
   });
 });
 

--- a/src/germanNumber.test.ts
+++ b/src/germanNumber.test.ts
@@ -22,7 +22,7 @@ describe('formatGermanNumber', () => {
     ).toBe('123,12');
     expect(
       formatGermanNumber(123.123456789, { maximumFractionDigits: 7 }),
-    ).toBe('123,1234567');
+    ).toBe('123,1234568');
     expect(formatGermanNumber(123.16, { maximumFractionDigits: 1 })).toBe(
       '123,2',
     );

--- a/src/germanNumber.test.ts
+++ b/src/germanNumber.test.ts
@@ -20,6 +20,9 @@ describe('formatGermanNumber', () => {
     expect(
       formatGermanNumber(123.123456789, { maximumFractionDigits: 2 }),
     ).toBe('123,12');
+    expect(
+      formatGermanNumber(123.123456789, { maximumFractionDigits: 7 }),
+    ).toBe('123,1234567');
     expect(formatGermanNumber(123.16, { maximumFractionDigits: 1 })).toBe(
       '123,2',
     );

--- a/src/germanNumber.ts
+++ b/src/germanNumber.ts
@@ -21,9 +21,14 @@ export function formatGermanNumber(
     return defaultValue ?? '';
   }
 
+  let { maximumFractionDigits } = localeOptions;
+  if (!maximumFractionDigits || maximumFractionDigits > 6) {
+    maximumFractionDigits = 6;
+  }
+
   return parsed.toLocaleString('de-DE', {
     ...localeOptions,
-    maximumFractionDigits: 6,
+    maximumFractionDigits,
   });
 }
 

--- a/src/germanNumber.ts
+++ b/src/germanNumber.ts
@@ -21,14 +21,9 @@ export function formatGermanNumber(
     return defaultValue ?? '';
   }
 
-  let { maximumFractionDigits } = localeOptions;
-  if (!maximumFractionDigits || maximumFractionDigits > 6) {
-    maximumFractionDigits = 6;
-  }
-
   return parsed.toLocaleString('de-DE', {
+    maximumFractionDigits: 6,
     ...localeOptions,
-    maximumFractionDigits,
   });
 }
 


### PR DESCRIPTION
The prop `maximumFractionDigits` is always being overwritten with the fix value 6. This value meant to be a maximum value through.