### PR TITLE
ci: validate PR titles follow conventional commits format

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,4 @@
-name: "Format"
+name: Format
 on:
   push:
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,19 @@
+name: PR Title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: "Release"
+name: Release
 on:
   push:
     branches:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,4 @@
-name: "Validate"
+name: Validate
 on:
   pull_request:
   push:


### PR DESCRIPTION
## Summary
- Add pr-title.yml workflow to validate PR titles follow conventional commits format
- Remove unnecessary quotes from workflow `name` fields for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)