### PR TITLE
fix: Update lodash to 4.17.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "date-fns": "3.0.1",
-    "lodash": "4.17.21"
+    "lodash": "4.17.23"
   },
   "devDependencies": {
     "@babel/core": "^7.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1873,7 +1873,7 @@ __metadata:
     eslint-plugin-unused-imports: "npm:^3.1.0"
     jest: "npm:^29.7.0"
     jest-environment-jsdom: "npm:^29.7.0"
-    lodash: "npm:4.17.21"
+    lodash: "npm:4.17.23"
     prettier: "npm:^3.1.0"
     rollup: "npm:^2.45.2"
     rollup-plugin-peer-deps-external: "npm:^2.2.4"
@@ -7640,7 +7640,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.21, lodash@npm:^4.17.4":
+"lodash@npm:4.17.23":
+  version: 4.17.23
+  resolution: "lodash@npm:4.17.23"
+  checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6
+  languageName: node
+  linkType: hard
+
+"lodash@npm:^4.17.4":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c


### PR DESCRIPTION
## Summary

- Update lodash from 4.17.21 to 4.17.23 to fix prototype pollution vulnerability in `_.unset` and `_.omit`
  - https://github.com/advisories/GHSA-xxjr-mmjv-4gpg

## Test plan

- [x] All 211 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)